### PR TITLE
Speed up BERT baseline 3X, improve its accuracy 

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -25,9 +25,9 @@ These are results on the data from 2015 to 2018 inclusive,  (`TABLE_REGEX="^201[
 | ELMO_SIM         | 12.5%             	|
 | ELMO_MAP         | 20.6%             	|
 | BERT_SMALL_SIM   | 17.1%             	|
-| BERT_SMALL_MAP   | 24.5%            	    |
-| BERT_LARGE_SIM   | 14.8%            	    |
-| BERT_LARGE_MAP   | 24.0%            	    |
+| BERT_SMALL_MAP   | 24.5%              |
+| BERT_LARGE_SIM   | 14.8%         	    |
+| BERT_LARGE_MAP   | 24.0%         	    |
 | **Other models** |                    |
 | PolyAI-Encoder [1]	  | 61.3%             	|
 
@@ -45,10 +45,10 @@ These are results on the data from 2015 to 2018 inclusive,  (`TABLE_REGEX="^201[
 | USE_LARGE_MAP    | 18.0%             	|
 | ELMO_SIM         | 9.5%             	|
 | ELMO_MAP         | 13.3%             	|
-| BERT_SMALL_SIM   | 13.8%               	|
-| BERT_SMALL_MAP   | 17.5%               	|
-| BERT_LARGE_SIM   | 12.2%               	|
-| BERT_LARGE_MAP   | 16.8%             	  |
+| BERT_SMALL_SIM   | 13.8%             	|
+| BERT_SMALL_MAP   | 17.5%             	|
+| BERT_LARGE_SIM   | 12.2%             	|
+| BERT_LARGE_MAP   | 16.8%           	  |
 | **Other models** |                    |
 | PolyAI-Encoder [1]	  | 30.6%             	|
 
@@ -66,10 +66,10 @@ These are results on the data from 2015 to 2018 inclusive,  (`TABLE_REGEX="^201[
 | USE_LARGE_MAP    | 61.9%             	|
 | ELMO_SIM         | 16.0%             	|
 | ELMO_MAP         | 35.5%             	|
-| BERT_SMALL_SIM   | 27.8%               	|
-| BERT_SMALL_MAP   | 45.8%               	|
-| BERT_LARGE_SIM   | 25.9%               	|
-| BERT_LARGE_MAP   | 44.1%             	  |
+| BERT_SMALL_SIM   | 27.8%              |
+| BERT_SMALL_MAP   | 45.8%             	|
+| BERT_LARGE_SIM   | 25.9%             	|
+| BERT_LARGE_MAP   | 44.1%           	  |
 | **Other models** |                    |
 | PolyAI-Encoder [1]	  | 84.2%             	|
 

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -24,10 +24,10 @@ These are results on the data from 2015 to 2018 inclusive,  (`TABLE_REGEX="^201[
 | USE_LARGE_MAP    | 47.7%             	|
 | ELMO_SIM         | 12.5%             	|
 | ELMO_MAP         | 20.6%             	|
-| BERT_SMALL_SIM         | 14.4%             	|
-| BERT_SMALL_MAP         | 20.5%             	|
-| BERT_LARGE_SIM         | 10.6%             	|
-| BERT_LARGE_MAP         | 17.1%             	|
+| BERT_SMALL_SIM   | 17.1%             	|
+| BERT_SMALL_MAP   | X%            	    |
+| BERT_LARGE_SIM   | X%            	    |
+| BERT_LARGE_MAP   | X%            	    |
 | **Other models** |                    |
 | PolyAI-Encoder [1]	  | 61.3%             	|
 
@@ -45,10 +45,10 @@ These are results on the data from 2015 to 2018 inclusive,  (`TABLE_REGEX="^201[
 | USE_LARGE_MAP    | 18.0%             	|
 | ELMO_SIM         | 9.5%             	|
 | ELMO_MAP         | 13.3%             	|
-| BERT_SMALL_SIM         | 13.8%             	|
-| BERT_SMALL_MAP         | 17.3%             	|
-| BERT_LARGE_SIM         | 9.9%             	|
-| BERT_LARGE_MAP         | 14.2%             	|
+| BERT_SMALL_SIM   | X%               	|
+| BERT_SMALL_MAP   | X%               	|
+| BERT_LARGE_SIM   | X%               	|
+| BERT_LARGE_MAP   | X%             	  |
 | **Other models** |                    |
 | PolyAI-Encoder [1]	  | 30.6%             	|
 
@@ -66,10 +66,10 @@ These are results on the data from 2015 to 2018 inclusive,  (`TABLE_REGEX="^201[
 | USE_LARGE_MAP    | 61.9%             	|
 | ELMO_SIM         | 16.0%             	|
 | ELMO_MAP         | 35.5%             	|
-| BERT_SMALL_SIM         | 16.1 %             	|
-| BERT_SMALL_MAP         | 37.6 %             	|
-| BERT_LARGE_SIM            | 12.3%          	|
-| BERT_LARGE_MAP         | 30.2%             	|
+| BERT_SMALL_SIM   | X%               	|
+| BERT_SMALL_MAP   | X%               	|
+| BERT_LARGE_SIM   | X%               	|
+| BERT_LARGE_MAP   | X%             	  |
 | **Other models** |                    |
 | PolyAI-Encoder [1]	  | 84.2%             	|
 

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -25,9 +25,9 @@ These are results on the data from 2015 to 2018 inclusive,  (`TABLE_REGEX="^201[
 | ELMO_SIM         | 12.5%             	|
 | ELMO_MAP         | 20.6%             	|
 | BERT_SMALL_SIM   | 17.1%             	|
-| BERT_SMALL_MAP   | X%            	    |
-| BERT_LARGE_SIM   | X%            	    |
-| BERT_LARGE_MAP   | X%            	    |
+| BERT_SMALL_MAP   | 24.5%            	    |
+| BERT_LARGE_SIM   | 14.8%            	    |
+| BERT_LARGE_MAP   | 24.0%            	    |
 | **Other models** |                    |
 | PolyAI-Encoder [1]	  | 61.3%             	|
 
@@ -45,10 +45,10 @@ These are results on the data from 2015 to 2018 inclusive,  (`TABLE_REGEX="^201[
 | USE_LARGE_MAP    | 18.0%             	|
 | ELMO_SIM         | 9.5%             	|
 | ELMO_MAP         | 13.3%             	|
-| BERT_SMALL_SIM   | X%               	|
-| BERT_SMALL_MAP   | X%               	|
-| BERT_LARGE_SIM   | X%               	|
-| BERT_LARGE_MAP   | X%             	  |
+| BERT_SMALL_SIM   | 13.8%               	|
+| BERT_SMALL_MAP   | 17.5%               	|
+| BERT_LARGE_SIM   | 12.2%               	|
+| BERT_LARGE_MAP   | 16.8%             	  |
 | **Other models** |                    |
 | PolyAI-Encoder [1]	  | 30.6%             	|
 
@@ -66,10 +66,10 @@ These are results on the data from 2015 to 2018 inclusive,  (`TABLE_REGEX="^201[
 | USE_LARGE_MAP    | 61.9%             	|
 | ELMO_SIM         | 16.0%             	|
 | ELMO_MAP         | 35.5%             	|
-| BERT_SMALL_SIM   | X%               	|
-| BERT_SMALL_MAP   | X%               	|
-| BERT_LARGE_SIM   | X%               	|
-| BERT_LARGE_MAP   | X%             	  |
+| BERT_SMALL_SIM   | 27.8%               	|
+| BERT_SMALL_MAP   | 45.8%               	|
+| BERT_LARGE_SIM   | 25.9%               	|
+| BERT_LARGE_MAP   | 44.1%             	  |
 | **Other models** |                    |
 | PolyAI-Encoder [1]	  | 84.2%             	|
 

--- a/baselines/vector_based.py
+++ b/baselines/vector_based.py
@@ -124,11 +124,12 @@ class BERTEncoder(Encoder):
             vocab_file=vocab_file, do_lower_case=do_lower_case)
 
     def _feed_dict(self, texts, max_seq_len=128):
-        """Create a feed dict for the texts.
+        """Create a feed dict for feeding the texts as input.
 
-        This uses dynamic padding so that the maximum sequence length the
+        This uses dynamic padding so that the maximum sequence length is the
         smaller of `max_seq_len` and the longest sequence actually found in the
-        batch. (The code in `bert.run_classifier` pads up to the maximum)
+        batch. (The code in `bert.run_classifier` always pads up to the maximum
+        even if the examples in the batch are all shorter.)
         """
         all_ids = []
         for text in texts:

--- a/baselines/vector_based.py
+++ b/baselines/vector_based.py
@@ -73,6 +73,10 @@ class BERTEncoder(Encoder):
     """
     def __init__(self, uri):
         """Create a new `BERTEncoder` object."""
+        if not tf.test.is_gpu_available():
+            glog.warning(
+                "No GPU detected, BERT will run a lot slower than with a GPU.")
+
         self._session = tf.Session(graph=tf.Graph())
         with self._session.graph.as_default():
             glog.info("Loading %s model from tensorflow hub", uri)

--- a/baselines/vector_based.py
+++ b/baselines/vector_based.py
@@ -78,12 +78,11 @@ class BERTEncoder(Encoder):
             glog.info("Loading %s model from tensorflow hub", uri)
             embed_fn = tensorflow_hub.Module(uri, trainable=False)
             self._tokenizer = self._create_tokenizer_from_hub_module(uri)
-            self._input_ids = tf.placeholder(shape=[None, None],
-                                             dtype=tf.int32)
-            self._input_mask = tf.placeholder(shape=[None, None],
-                                              dtype=tf.int32)
-            self._segment_ids = tf.placeholder(shape=[None, None],
-                                               dtype=tf.int32)
+            self._input_ids = tf.placeholder(
+                name="input_ids", shape=[None, None], dtype=tf.int32)
+            self._input_mask = tf.placeholder(
+                name="input_mask", shape=[None, None], dtype=tf.int32)
+            self._segment_ids = tf.zeros_like(self._input_ids)
             bert_inputs = dict(
                 input_ids=self._input_ids,
                 input_mask=self._input_mask,
@@ -94,7 +93,9 @@ class BERTEncoder(Encoder):
                 inputs=bert_inputs, signature="tokens", as_dict=True)[
                 "sequence_output"
             ]
-            self._embeddings = tf.reduce_sum(embeddings, axis=1)
+            mask = tf.expand_dims(
+                tf.cast(self._input_mask, dtype=tf.float32), -1)
+            self._embeddings = tf.reduce_sum(mask * embeddings, axis=1)
 
             init_ops = (
                 tf.global_variables_initializer(), tf.tables_initializer())
@@ -103,33 +104,13 @@ class BERTEncoder(Encoder):
 
     def encode(self, texts):
         """Encode the given texts."""
-        input_examples = [bert.run_classifier.InputExample(
-            guid="", text_a=x, text_b=None, label=0)
-            for x in texts]  # here, "" is just a dummy label
-        label_list = [0]  # dummy label
-        max_seq_length = 128
-        input_features = bert.run_classifier.convert_examples_to_features(
-            input_examples, label_list, max_seq_length, self._tokenizer)
-        input_ids = []
-        input_mask = []
-        segment_ids = []
-
-        for feat in input_features:
-            input_ids.append(feat.input_ids)
-            input_mask.append(feat.input_mask)
-            segment_ids.append(feat.segment_ids)
-
-        return self._session.run(
-            self._embeddings,
-            {self._input_ids: input_ids,
-             self._input_mask: input_mask,
-             self._segment_ids: segment_ids})
+        return self._session.run(self._embeddings, self._feed_dict(texts))
 
     @staticmethod
     def _create_tokenizer_from_hub_module(uri):
         """Get the vocab file and casing info from the Hub module."""
         with tf.Graph().as_default():
-            bert_module = tensorflow_hub.Module(uri)
+            bert_module = tensorflow_hub.Module(uri, trainable=False)
             tokenization_info = bert_module(
                 signature="tokenization_info", as_dict=True)
             with tf.Session() as sess:
@@ -141,6 +122,40 @@ class BERTEncoder(Encoder):
 
         return bert.tokenization.FullTokenizer(
             vocab_file=vocab_file, do_lower_case=do_lower_case)
+
+    def _feed_dict(self, texts, max_seq_len=128):
+        """Create a feed dict for the texts.
+
+        This uses dynamic padding so that the maximum sequence length the
+        smaller of `max_seq_len` and the longest sequence actually found in the
+        batch. (The code in `bert.run_classifier` pads up to the maximum)
+        """
+        all_ids = []
+        for text in texts:
+            tokens = ["[CLS]"] + self._tokenizer.tokenize(text)
+
+            # Possibly truncate the tokens.
+            tokens = tokens[:(max_seq_len - 1)]
+            tokens.append("[SEP]")
+            ids = self._tokenizer.convert_tokens_to_ids(tokens)
+            all_ids.append(ids)
+
+        max_seq_len = max(map(len, all_ids))
+
+        input_ids = []
+        input_mask = []
+        for ids in all_ids:
+            mask = [1] * len(ids)
+
+            # Zero-pad up to the sequence length.
+            while len(ids) < max_seq_len:
+                ids.append(0)
+                mask.append(0)
+
+            input_ids.append(ids)
+            input_mask.append(mask)
+
+        return {self._input_ids: input_ids, self._input_mask: input_mask}
 
 
 class VectorSimilarityMethod(method.BaselineMethod):


### PR DESCRIPTION
- speed up by optimizing the padding
- improve accuracy by masking the sequence embeddings before the reduce_sum

also add a unit test for the bert encoder

i am re-running the baseline and will fill in results soon